### PR TITLE
Add resource prefixing and initial demo-app configuration

### DIFF
--- a/infra/cluster.tf
+++ b/infra/cluster.tf
@@ -8,13 +8,13 @@ provider "kubernetes" {
 
 resource "kubernetes_namespace" "runner" {
   metadata {
-    name = "humanitec-runner"
+    name = "${local.prefix}-humanitec-runner"
   }
 }
 
 resource "kubernetes_service_account" "runner" {
   metadata {
-    name      = "humanitec-runner-sa"
+    name      = "${local.prefix}-humanitec-runner-sa"
     namespace = kubernetes_namespace.runner.metadata[0].name
     annotations = {
       "iam.gke.io/gcp-service-account" = google_service_account.runner.email
@@ -24,7 +24,7 @@ resource "kubernetes_service_account" "runner" {
 
 resource "kubernetes_role" "orchestrator_access" {
   metadata {
-    name      = "humanitec-runner-orchestrator-access"
+    name      = "${local.prefix}-humanitec-runner-orchestrator-access"
     namespace = kubernetes_namespace.runner.metadata[0].name
   }
 
@@ -50,7 +50,7 @@ resource "kubernetes_role" "orchestrator_access" {
 
 resource "kubernetes_role_binding" "orchestrator_access" {
   metadata {
-    name      = "humanitec-runner-orchestrator-access"
+    name      = "${local.prefix}-humanitec-runner-orchestrator-access"
     namespace = kubernetes_namespace.runner.metadata[0].name
   }
 
@@ -74,7 +74,7 @@ resource "kubernetes_role_binding" "orchestrator_access" {
 
 resource "kubernetes_cluster_role_binding" "runner_cluster_admin" {
   metadata {
-    name = "humanitec-runner-cluster-admin"
+    name = "${local.prefix}-humanitec-runner-cluster-admin"
   }
 
   role_ref {

--- a/infra/google.tf
+++ b/infra/google.tf
@@ -4,19 +4,19 @@ provider "google" {
 }
 
 resource "google_compute_network" "vpc" {
-  name                    = "first-deployment-vpc"
+  name                    = "${local.prefix}-first-deployment-vpc"
   auto_create_subnetworks = "false"
 }
 
 resource "google_compute_subnetwork" "subnet" {
-  name          = "first-deployment-subnet"
+  name          = "${local.prefix}-first-deployment-subnet"
   region        = var.gcp_region
   network       = google_compute_network.vpc.name
   ip_cidr_range = "10.10.0.0/24"
 }
 
 resource "google_container_cluster" "cluster" {
-  name     = "first-deployment-gke"
+  name     = "${local.prefix}-first-deployment-gke"
   location = var.gcp_region
 
   initial_node_count = 2
@@ -32,12 +32,12 @@ resource "google_container_cluster" "cluster" {
 
 
 resource "google_iam_workload_identity_pool" "wip" {
-  workload_identity_pool_id = "first-deployment-wip"
+  workload_identity_pool_id = "${local.prefix}-first-deployment-wip"
 }
 
 resource "google_iam_workload_identity_pool_provider" "wip_provider" {
   workload_identity_pool_id          = google_iam_workload_identity_pool.wip.workload_identity_pool_id
-  workload_identity_pool_provider_id = "first-deployment-wip-provider"
+  workload_identity_pool_provider_id = "${local.prefix}-first-deploy-wip-provider"
   attribute_mapping = {
     "google.subject" = "assertion.sub"
   }
@@ -47,7 +47,7 @@ resource "google_iam_workload_identity_pool_provider" "wip_provider" {
 }
 
 resource "google_service_account" "runner" {
-  account_id   = "first-deployment-runner"
+  account_id   = "${local.prefix}-first-deployment-runner"
   display_name = "Used by Humanitec Orchestrator to access GKE clusters for launching runners"
 }
 
@@ -58,12 +58,12 @@ data "google_project" "project" {
 resource "google_service_account_iam_member" "runner_workload_identity_binding" {
   service_account_id = google_service_account.runner.name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "principal://iam.googleapis.com/projects/${data.google_project.project.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.wip.workload_identity_pool_id}/subject/${var.humanitec_org}+first-deployment-gke-runner"
+  member             = "principal://iam.googleapis.com/projects/${data.google_project.project.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.wip.workload_identity_pool_id}/subject/${var.humanitec_org}+${local.prefix}-first-deployment-gke-runner"
 }
 
 resource "google_project_iam_custom_role" "runner" {
-  role_id     = "first_deployment_runner_role"
-  title       = "first_deployment_runner_role"
+  role_id     = "${local.prefix}_first_deployment_runner_role"
+  title       = "${local.prefix}_first_deployment_runner_role"
   description = "Access for the Humanitec Orchestrator to GKE clusters for launching runners"
   project     = var.gcp_project_id
 

--- a/infra/humanitec.tf
+++ b/infra/humanitec.tf
@@ -22,7 +22,7 @@ resource "kubernetes_secret" "google_service_account" {
 }
 
 resource "platform-orchestrator_kubernetes_gke_runner" "runner" {
-  id          = "first-deployment-gke-runner"
+  id          = "${local.prefix}-first-deployment-gke-runner"
   description = "GKE runner for Humanitec Orchestrator to launch runners in all environments"
 
   runner_configuration = {
@@ -89,12 +89,12 @@ resource "platform-orchestrator_runner_rule" "runner_rule" {
 }
 
 resource "platform-orchestrator_environment_type" "environment_type" {
-  id           = "development"
+  id           = "${local.prefix}-development"
   display_name = "Development Environment"
 }
 
 resource "platform-orchestrator_project" "project" {
-  id         = "tutorial"
+  id         = "${local.prefix}-tutorial"
   depends_on = [platform-orchestrator_runner_rule.runner_rule]
 }
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -20,7 +20,24 @@ terraform {
       source  = "humanitec/platform-orchestrator"
       version = ">= 2.4.0"
     }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
   }
 
   required_version = ">= 0.14"
+}
+
+resource "random_string" "prefix" {
+  length  = 4
+  lower   = true
+  upper   = false
+  numeric = false
+  special = false
+}
+
+locals {
+  prefix = var.prefix != "" ? var.prefix : random_string.prefix.result
 }

--- a/infra/modules.tf
+++ b/infra/modules.tf
@@ -24,6 +24,8 @@ resource "platform-orchestrator_resource_type" "bucket" {
     }
   })
   is_developer_accessible = true
+
+  depends_on = [ platform-orchestrator_provider.google ]
 }
 
 resource "platform-orchestrator_module" "bucket" {
@@ -35,9 +37,8 @@ resource "platform-orchestrator_module" "bucket" {
     google = "google.default"
   }
   module_inputs = jsonencode({
-    google_storage_bucket_name = "first-deployment-bucket"
+    google_storage_bucket_name = "${local.prefix}-first-deployment-bucket"
   })
-  depends_on = [platform-orchestrator_provider.google]
 }
 
 resource "platform-orchestrator_module_rule" "bucket" {
@@ -56,6 +57,8 @@ resource "platform-orchestrator_resource_type" "queue" {
     }
   })
   is_developer_accessible = true
+
+  depends_on = [ platform-orchestrator_provider.google ]
 }
 
 resource "platform-orchestrator_module" "queue" {
@@ -67,7 +70,7 @@ resource "platform-orchestrator_module" "queue" {
     google = "google.default"
   }
   module_inputs = jsonencode({
-    topic_name = "first-deployment-topic"
+    topic_name = "${local.prefix}-first-deployment-topic"
   })
   depends_on = [platform-orchestrator_provider.google]
 }
@@ -97,6 +100,7 @@ resource "platform-orchestrator_resource_type" "k8s-namespace" {
     }
   })
   is_developer_accessible = true
+  depends_on = [ platform-orchestrator_provider.k8s ]
 }
 
 resource "platform-orchestrator_module" "k8s-namespace" {
@@ -107,7 +111,6 @@ resource "platform-orchestrator_module" "k8s-namespace" {
   provider_mapping = {
     kubernetes = "kubernetes.default"
   }
-  depends_on = [platform-orchestrator_provider.k8s]
 }
 
 resource "platform-orchestrator_module_rule" "k8s-namespace" {
@@ -126,6 +129,7 @@ resource "platform-orchestrator_resource_type" "k8s-service-account" {
     }
   })
   is_developer_accessible = true
+  depends_on = [ platform-orchestrator_provider.k8s ]
 }
 
 # TODO: This module is using a hardcoded GCP service account email, we should create a module and use it here as dependency
@@ -149,7 +153,6 @@ resource "platform-orchestrator_module" "k8s-service-account" {
     namespace                 = "$${resources.namespace.outputs.namespace}"
     project_id                = var.gcp_project_id
   })
-  depends_on = [platform-orchestrator_provider.k8s]
 }
 
 resource "platform-orchestrator_module_rule" "k8s-service-account" {
@@ -180,6 +183,7 @@ resource "platform-orchestrator_resource_type" "in-cluster-postgres" {
     }
   })
   is_developer_accessible = true
+  depends_on = [ platform-orchestrator_provider.k8s ]
 }
 
 resource "platform-orchestrator_provider" "helm" {
@@ -203,6 +207,7 @@ resource "platform-orchestrator_resource_type" "score-workload" {
     }
   })
   is_developer_accessible = true
+  depends_on = [ platform-orchestrator_provider.helm, platform-orchestrator_provider.ansibleplay ]
 }
 
 resource "platform-orchestrator_provider" "ansibleplay" {
@@ -238,6 +243,7 @@ resource "platform-orchestrator_resource_type" "vm-fleet" {
     }
   })
   is_developer_accessible = true
+  depends_on = [ platform-orchestrator_provider.google ]
 }
 resource "platform-orchestrator_module" "vm_fleet_example" {
   id = "vm-fleet-example"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -17,3 +17,9 @@ variable "humanitec_org" {
 variable "humanitec_auth_token" {
   description = "Humanitec auth token"
 }
+
+variable "prefix" {
+  description = "Prefix for resources to allow multiple instances (4 random chars if empty)"
+  type        = string
+  default     = ""
+}

--- a/manifests/manifest.yaml
+++ b/manifests/manifest.yaml
@@ -1,0 +1,1 @@
+workloads: {}

--- a/manifests/manifest2.yaml
+++ b/manifests/manifest2.yaml
@@ -1,0 +1,20 @@
+workloads:
+  demo-app:
+    resources:
+      score-workload:
+        params:
+          containers:
+            main:
+              image: ghcr.io/astromechza/demo-app:latest
+          metadata:
+            name: demo-app
+          service:
+            ports:
+              web:
+                port: 80
+                targetPort: 8080
+        type: score-workload
+      db:
+        type: postgres
+    variables:
+      OVERRIDE_POSTGRES: postgres://${resources.db.outputs.username}:${resources.db.outputs.password}@${resources.db.outputs.hostname}:${resources.db.outputs.port}/${resources.db.outputs.database}

--- a/manifests/score.yaml
+++ b/manifests/score.yaml
@@ -1,0 +1,11 @@
+apiVersion: score.dev/v1b1
+metadata:
+  name: demo-app
+containers:
+  main:
+    image: ghcr.io/astromechza/demo-app:latest
+service:
+  ports:
+    web:
+      port: 80
+      targetPort: 8080


### PR DESCRIPTION
Introduce a prefix for main resources to support multiple instances and add initial manifest files for demo-app workloads and score configuration.

Signed-off-by: jayonthenet <clemens@humanitec.com>